### PR TITLE
Fix delta detection for product updates

### DIFF
--- a/namwoo_app/utils/product_utils.py
+++ b/namwoo_app/utils/product_utils.py
@@ -20,8 +20,7 @@ def generate_product_location_id(item_code_raw: Any, whs_name_raw: Any) -> Optio
         return None 
 
     sanitized_whs_name = re.sub(r'[^a-zA-Z0-9_-]', '_', whs_name)
-    product_id = f"{item_code}_{sanitized_whs_name}".lower() # <<< FIX: ADDED .lower() FOR CONSISTENCY
-    if len(product_id) > 512: # Max length of Product.id
-        # logger.warning(f"Generated product_location_id for {item_code} was truncated to 512 chars.")
+    product_id = f"{item_code}_{sanitized_whs_name}"
+    if len(product_id) > 512:
         product_id = product_id[:512]
     return product_id


### PR DESCRIPTION
## Summary
- avoid lowercasing product ID generation
- detect and update only changed product fields instead of always overwriting
- add newline at EOF

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855fb0abdac832b80820d57a5e97fe2