### PR TITLE
Enhance JSON logging utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ A key aspect is distinguishing messages from different sources to ensure correct
 | |-- tasks.py
 |-- data/ # Project-level data (e.g., SQL schema if not using migrations)
 | |-- schema.sql # Must include 'description', 'llm_summarized_description', and 'conversation_pauses' table
-|-- logs/ # Created at runtime for log files
+|-- logs/ # Created at runtime for log files (including **app.json** with timestamped JSON log entries)
+    * Utility `setup_json_file_logger` can be used by standalone scripts to attach a JSON logger
 |-- venv/ # Python virtual environment (.gitignored)
 |-- .env # Environment variables (SECRET! .gitignored)
 |-- .env.example # Example environment variables

--- a/namwoo_app/utils/logging_utils.py
+++ b/namwoo_app/utils/logging_utils.py
@@ -1,14 +1,56 @@
 import logging
 import json
+import os
+from logging.handlers import RotatingFileHandler
 
 class JsonFormatter(logging.Formatter):
-    """Format log records as JSON with timestamp and level."""
+    """Format log records as JSON with detailed context."""
 
-    def format(self, record: logging.LogRecord) -> str:
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - simple serializer
+        """Return the given record serialized as a JSON string."""
         log_entry = {
             "timestamp": self.formatTime(record, self.datefmt or "%Y-%m-%d %H:%M:%S"),
             "level": record.levelname,
             "name": record.name,
+            "module": record.module,
+            "funcName": record.funcName,
+            "line": record.lineno,
             "message": record.getMessage(),
         }
+
+        if record.exc_info:
+            log_entry["exception"] = self.formatException(record.exc_info)
+
         return json.dumps(log_entry)
+
+
+def setup_json_file_logger(log_file: str, level: int = logging.INFO) -> RotatingFileHandler:
+    """Attach a RotatingFileHandler with :class:`JsonFormatter` to the root logger.
+
+    Parameters
+    ----------
+    log_file:
+        Path to the JSON log file.
+    level:
+        Logging level for the handler and root logger (default: ``logging.INFO``).
+
+    Returns
+    -------
+    RotatingFileHandler
+        The handler that was added. Call ``root_logger.removeHandler`` on it when done.
+    """
+
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    handler = RotatingFileHandler(
+        filename=log_file,
+        maxBytes=10_485_760,
+        backupCount=5,
+        encoding="utf8",
+    )
+    handler.setLevel(level)
+    handler.setFormatter(JsonFormatter(datefmt="%Y-%m-%d %H:%M:%S"))
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+    root_logger.addHandler(handler)
+    return handler

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,48 @@
+import json
+import logging
+import os
+import importlib.util
+
+UTILS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "namwoo_app", "utils", "logging_utils.py"))
+spec = importlib.util.spec_from_file_location("logging_utils", UTILS_PATH)
+logging_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(logging_utils)
+JsonFormatter = logging_utils.JsonFormatter
+
+
+def test_json_formatter_basic_fields():
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname="/tmp/test.py",
+        lineno=42,
+        msg="hello",
+        args=(),
+        exc_info=None,
+        func="test_func",
+    )
+    formatter = JsonFormatter(datefmt="%Y-%m-%d %H:%M:%S")
+    output = formatter.format(record)
+    data = json.loads(output)
+    assert data["level"] == "INFO"
+    assert data["name"] == "test_logger"
+    assert data["message"] == "hello"
+    assert data["funcName"] == "test_func"
+    assert data["line"] == 42
+    assert "timestamp" in data
+
+
+def test_setup_json_file_logger_writes(tmp_path):
+    log_file = tmp_path / "app.json"
+    handler = logging_utils.setup_json_file_logger(str(log_file))
+    logger = logging.getLogger("test_setup_json_file_logger")
+    logger.info("json hello")
+    handler.flush()
+    logging.getLogger().removeHandler(handler)
+
+    with open(log_file, "r", encoding="utf8") as f:
+        line = json.loads(f.readline())
+
+    assert line["message"] == "json hello"
+    assert line["name"] == "test_setup_json_file_logger"
+


### PR DESCRIPTION
## Summary
- add `setup_json_file_logger` helper to easily attach a JSON RotatingFileHandler
- document standalone JSON logger utility in the project layout
- test new helper alongside JsonFormatter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856d706e0c4832b804821269042de67